### PR TITLE
Add `pluginSectionLinks` to make it work on Strapi 3.1.x

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -7,12 +7,14 @@ import trads from './translations';
 
 export default strapi => {
   const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
+  const pluginName = pluginPkg.strapi.name || pluginPkg.name;
+  const pluginIcon = pluginPkg.strapi.icon
 
   const plugin = {
     blockerComponent: null,
     blockerComponentProps: {},
     description: pluginDescription,
-    icon: pluginPkg.strapi.icon,
+    icon: pluginIcon,
     id: pluginId,
     initializer: Initializer,
     injectedComponents: [],
@@ -21,6 +23,19 @@ export default strapi => {
     layout: null,
     lifecycles,
     leftMenuLinks: [],
+    menu: {
+      pluginsSectionLinks: [
+        {
+          destination: `/plugins/${pluginId}`,
+          icon: pluginIcon,
+          name: pluginName,
+          label: {
+            id: `${pluginId}.plugin.name`,
+            defaultMessage: pluginName,
+          },
+        },
+      ],
+    },
     leftMenuSections: [],
     mainComponent: App,
     name: pluginPkg.strapi.name,


### PR DESCRIPTION
This change is needed because with the new RBAC feature of Strapi,
all the plugins resides in a pluginSectionLinks key.

You can see the migration guide here:
https://strapi.io/documentation/v3.x/migration-guide/migration-guide-3.0.x-to-3.1.x.html#_3-migrate-your-custom-admin-panel-plugins