### PR TITLE
add property overflow-y:auto to add scroll on smaller screens

### DIFF
--- a/admin/src/containers/HomePage/main.css
+++ b/admin/src/containers/HomePage/main.css
@@ -1,5 +1,6 @@
 .srd-diagram {
   height: 80vh;
+  overflow-y: auto;
 }
 
 .srd-default-link path{


### PR DESCRIPTION
Add property css overflow-y:auto to add scroll on smaller screens.

Before add overflow-y:auto
![hidden](https://user-images.githubusercontent.com/65097513/103181925-60fd5f00-4885-11eb-86ed-29e3898aa400.png)

After add overflow-y:auto
![with-overflow-y-auto](https://user-images.githubusercontent.com/65097513/103181944-868a6880-4885-11eb-8bb5-4576393b0d94.png)
